### PR TITLE
build(jenkins): fix up jenkins usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,36 +6,25 @@ def nodeVersion = '8.9.1'
 def unitTests(os, nodeVersion) {
   return {
     node(os) {
-      nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
-        stage('Test') {
+      try {
+        nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
           timeout(15) {
             unstash 'sources'
             // Install yarn if not installed
-            if('windows'.equals(os)) {
-              if (bat(returnStatus: true, script: 'where yarn') != 0) {
-                bat 'npm install -g yarn'
-              }
-              bat 'yarn install'
-            } else {
-              if (sh(returnStatus: true, script: 'which yarn') != 0) {
-                sh 'npm install -g yarn'
-              }
-              sh 'yarn install'
-           }
-           fingerprint 'package.json'
+            ensureYarn()
+            command 'yarn install' // runs bat on win, sh on unix/mac
+
             try {
-              if('windows'.equals(os)) {
-                bat 'yarn run coverage'
-              } else {
-                sh 'yarn run coverage'
-              }
+              command 'yarn run coverage' // runs bat on win, sh on unix/mac
             } finally {
               // record results even if tests/coverage 'fails'
               junit 'junit.xml'
             }
           } // timeout
-        } // test
-      } // nodejs
+        } // nodejs
+      } finally {
+        deleteDir() // wipe the workspace no matter what
+      }
     }  // node
   }
 }
@@ -59,7 +48,8 @@ timestamps {
       isMaster = env.BRANCH_NAME.equals('master')
       packageVersion = jsonParse(readFile('package.json'))['version']
       currentBuild.displayName = "#${packageVersion}-${currentBuild.number}"
-      stash allowEmpty: true, name: 'sources', useDefaultExcludes: false
+      fingerprint 'package.json'
+      stash 'sources'
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,10 @@ def unitTests(os, nodeVersion) {
             } finally {
               // record results even if tests/coverage 'fails'
               junit 'junit.xml'
+
+              if (fileExists('coverage/cobertura-coverage.xml')) {
+								step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage/cobertura-coverage.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])
+							}
             }
           } // timeout
         } // nodejs


### PR DESCRIPTION
This will:
- wipe the workspace after running tests so next time we have a clean node to work with
- not get confused about stages by having same stage defined multiple times
- fix stash/unstash to use default excludes, or else it tries to copy the .git dir too (and fails due to permissions issues)
- uses the generic `command` step to run `bat` on windows or `sh` on unix/mac under the hood.
- uses the `ensureYarn()` command to install latest yarn when necessary
- fingerprints the package.json just once (not once per OS)
- if available, will record cobertura code coverage results