### PR TITLE
fix: Updated 'releases.json' URL to use the virtual-hosted style URL …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.2
+
+ * fix: Updated `releases.json` URL to use the virtual-hosted style URL instead of the path-style
+   URL (https://forums.aws.amazon.com/ann.jspa?annID=6776).
+
 # 1.3.1 (Apr 24, 2019)
 
  * refactor: Added `name` to SDK object returned from `getReleases()`.

--- a/src/options.js
+++ b/src/options.js
@@ -20,7 +20,7 @@ const options = {
 			branches: 'http://builds.appcelerator.com/mobile/branches.json',
 			build:    'http://builds.appcelerator.com/mobile/<BRANCH>/<FILENAME>',
 			builds:   'http://builds.appcelerator.com/mobile/<BRANCH>/index.json',
-			releases: 'https://s3-us-west-2.amazonaws.com/appc-mobilesdk-server/releases.json'
+			releases: 'https://appc-mobilesdk-server.s3-us-west-2.amazonaws.com/releases.json'
 		}
 	},
 	module: {


### PR DESCRIPTION
fix: Updated `releases.json` URL to use the virtual-hosted style URL instead of the path-style URL to address https://forums.aws.amazon.com/ann.jspa?annID=6776.