### PR TITLE
fix(util): call reject with the error instance directly

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -154,7 +154,7 @@ export function fetchJSON(url) {
 		log(`Fetching ${highlight(url)}`);
 		request(buildRequestParams({ method: 'GET', url }), (err, response, body) => {
 			if (err) {
-				return reject(new Error(err));
+				return reject(err);
 			}
 
 			// istanbul ignore if


### PR DESCRIPTION
If create a new Error with err, then we lose any extra info like code that can be useful to consumers of titaniumlib